### PR TITLE
fix(transitive): Generate transitive data without latitude longitude …

### DIFF
--- a/lib/get-transitive-data.js
+++ b/lib/get-transitive-data.js
@@ -4,6 +4,7 @@ import Color from 'color'
 import dbg from 'debug'
 import fill from 'lodash.fill'
 import slice from 'lodash.slice'
+import ll from 'lonlng'
 
 import {pixelToLat, pixelToLon} from './mercator'
 import {getNonTransitTime, ITERATION_WIDTH} from './origin'
@@ -18,25 +19,33 @@ const MAX_PATH_SEGMENTS = 8
 // arbitrary value that determines how aggressively to cluster results (higher is more aggressive, and a high number is something like 1e-3)
 const MAXIMUM_DISSIMILARITY = 5e-6
 
-export default function getTransitiveData ({origin, query, stopTreeCache, network, to}) {
+export default function getTransitiveData ({ origin, query, stopTreeCache, network, from, to }) {
   // create the journeys
   let output = {
     places: [],
     journeys: []
   }
 
+  // from can be left null and it will be inferred from the destination
+  const fromCoord = from != null ? ll(from) : {}
+
   output.places.push({
     place_id: 'from',
-    place_name: 'Origin', // todo do this with icons, avoid English works (or Portuguese words, for that matter)
-    place_lat: pixelToLat(query.north + origin.y, query.zoom),
-    place_lon: pixelToLon(query.west + origin.x, query.zoom)
+    place_name: from.name || 'Origin', // todo do this with icons, avoid English works (or Portuguese words, for that matter)
+    place_lat: fromCoord.lat || pixelToLat(query.north + origin.y, query.zoom),
+    place_lon: fromCoord.lon || pixelToLon(query.west + origin.x, query.zoom)
   })
+
+  // to cannot be undefined
+  // Omit X and Y so as not to confuse lonlng
+  const { x, y, ...rest } = to
+  const toCoord = ll(rest)
 
   output.places.push({
     place_id: 'to',
     place_name: to.name || 'Destination',
-    place_lat: pixelToLat(query.north + to.y, query.zoom),
-    place_lon: pixelToLon(query.west + to.x, query.zoom)
+    place_lat: toCoord.lat || pixelToLat(query.north + to.y, query.zoom),
+    place_lon: toCoord.lon || pixelToLon(query.west + to.x, query.zoom)
   })
 
   // find relevant paths at each minute

--- a/lib/index.js
+++ b/lib/index.js
@@ -87,11 +87,16 @@ export default class Browsochrones extends WebWorkerPromiseInterface {
     })
   }
 
-  generateDestinationData (point) {
+  generateDestinationData ({ from, to }) {
+    if (!this.isLoaded()) {
+      return Promise.reject(new Error('Transitive data cannot be generated if Browsochrones is not fully loaded.'))
+    }
+
     return this.work({
       command: 'generateDestinationData',
       message: {
-        point
+        from,
+        to
       }
     })
   }
@@ -110,19 +115,6 @@ export default class Browsochrones extends WebWorkerPromiseInterface {
       command: 'getPath',
       message: {
         path
-      }
-    })
-  }
-
-  generateTransitiveData (point) {
-    if (!this.isLoaded()) {
-      return Promise.reject(new Error('Transitive data cannot be generated if Browsochrones is not fully loaded.'))
-    }
-
-    return this.work({
-      command: 'generateTransitiveData',
-      message: {
-        point
       }
     })
   }

--- a/lib/worker-handlers.js
+++ b/lib/worker-handlers.js
@@ -55,44 +55,35 @@ module.exports = createHandler({
     })
   },
   generateDestinationData (ctx, message) {
-    const {point} = message
+    const { to, from } = message
 
-    let travelTime = ctx.surface.surface[point.y * ctx.query.width + point.x]
-    let waitTime = ctx.surface.waitTimes[point.y * ctx.query.width + point.x]
+    let travelTime = ctx.surface.surface[to.y * ctx.query.width + to.x]
+    let waitTime = ctx.surface.waitTimes[to.y * ctx.query.width + to.x]
     // NB separate walk time surface because some summary statistics don't preserve stat(wait) +
     //   stat(walk) + stat(inVehicle) = stat(total)
-    let walkTime = ctx.surface.walkTimes[point.y * ctx.query.width + point.x]
-    let inVehicleTravelTime = ctx.surface.inVehicleTravelTimes[point.y * ctx.query.width + point.x]
+    let walkTime = ctx.surface.walkTimes[to.y * ctx.query.width + to.x]
+    let inVehicleTravelTime = ctx.surface.inVehicleTravelTimes[to.y * ctx.query.width + to.x]
 
     return {
       paths: getPaths({
         origin: ctx.origin,
         query: ctx.query,
         stopTreeCache: ctx.stopTreeCache,
-        to: point
+        to
       }),
       transitive: getTransitiveData({
         network: ctx.transitiveNetwork,
         origin: ctx.origin,
+        from,
+        to,
         query: ctx.query,
-        stopTreeCache: ctx.stopTreeCache,
-        to: point
+        stopTreeCache: ctx.stopTreeCache
       }),
       travelTime,
       waitTime,
       inVehicleTravelTime,
       walkTime
     }
-  },
-  generateTransitiveData (ctx, message) {
-    ctx.transitiveData = getTransitiveData({
-      network: ctx.transitiveNetwork,
-      origin: ctx.origin,
-      query: ctx.query,
-      stopTreeCache: ctx.stopTreeCache,
-      to: message.point
-    })
-    return ctx.transitiveData
   },
   getContour (ctx, message) {
     ctx.contour = getContour({

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "leaflet": "^0.7.7",
     "lodash.fill": "^3.3.2",
     "lodash.slice": "^4.0.2",
+    "lonlng": "^0.2.0",
     "web-worker-promise-interface": "^0.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
…snapping to query grid. BREAKIN

Generate transitive dat without lat lon snapping, required some API changes. getTransitiveData is

now gone, replaced with getDestinationData, and params have chnaged.

API of getDestinationData has a BREAKING CHANGE.

I removed getTransitiveData as you can use getDestinationData to get the same thing as well as the travel times. You now call getDestination data with `{ from, to }`; `from` is optional but allows you to specify the exact `lat`, `lon` and `name` of the origin. `to` must contain `x` and `y` coords in the query (which is what was previously passed to getDestinationData) but can also contain `lat`, `lon` and `name`.
