### PR TITLE
feat(origin): Throw error if file is truncated, do bounds checks.

### DIFF
--- a/lib/origin.js
+++ b/lib/origin.js
@@ -68,6 +68,11 @@ export function create (data, point) {
     }
   }
 
+  // Javascript does no bounds checks. Ensure we didn't under or overrun.
+  if (offset !== data.length) {
+    throw new Error(`Expected ${offset * 4} bytes but only received ${data.length * 4} bytes`)
+  }
+
   return origin
 }
 

--- a/lib/origin.js
+++ b/lib/origin.js
@@ -70,7 +70,7 @@ export function create (data, point) {
 
   // Javascript does no bounds checks. Ensure we didn't under or overrun.
   if (offset !== data.length) {
-    throw new Error(`Expected ${offset * 4} bytes but only received ${data.length * 4} bytes`)
+    throw new Error('Data for origin corrupted (network issues?)')
   }
 
   return origin

--- a/lib/stop-tree-cache.js
+++ b/lib/stop-tree-cache.js
@@ -18,7 +18,7 @@ export function create (data, size) {
   // function that reads from array performing bounds checks
   const read = (idx) => {
     if (idx >= data.length) {
-      throw new Error('attempted to read past end of stop tree cache!')
+      throw new Error('Stop trees corrupted (network issues?)')
     } else {
       return data[idx]
     }
@@ -41,7 +41,7 @@ export function create (data, size) {
   }
 
   if (pixelsRead !== size) {
-    throw new Error(`Expected to read ${size} pixels but read only ${pixelsRead}`)
+    throw new Error(`Stop trees corrupted (network issues?): Expected to read ${size} pixels but read only ${pixelsRead}`)
   }
 
   return stopTreeCache

--- a/lib/stop-tree-cache.js
+++ b/lib/stop-tree-cache.js
@@ -25,8 +25,7 @@ export function create (data, size) {
   }
 
   // build the index and de-delta-code
-  let pixelsRead = 0
-  for (let i = 0, pixel = 0, stopId = 0, time = 0; i < data.length; pixel++) {
+  for (let i = 0, pixel = 0, stopId = 0, time = 0; pixel < size; pixel++) {
     stopTreeCache.index[pixel] = i
     const nStops = read(i++)
 
@@ -36,12 +35,6 @@ export function create (data, size) {
       time += read(i)
       data[i++] = time
     }
-
-    pixelsRead++
-  }
-
-  if (pixelsRead !== size) {
-    throw new Error(`Stop trees corrupted (network issues?): Expected to read ${size} pixels but read only ${pixelsRead}`)
   }
 
   return stopTreeCache

--- a/lib/stop-tree-cache.js
+++ b/lib/stop-tree-cache.js
@@ -15,16 +15,33 @@ export function create (data, size) {
   stopTreeCache.data = data
   stopTreeCache.index = new Int32Array(size)
 
+  // function that reads from array performing bounds checks
+  const read = (idx) => {
+    if (idx >= data.length) {
+      throw new Error('attempted to read past end of stop tree cache!')
+    } else {
+      return data[idx]
+    }
+  }
+
   // build the index and de-delta-code
+  let pixelsRead = 0
   for (let i = 0, pixel = 0, stopId = 0, time = 0; i < data.length; pixel++) {
     stopTreeCache.index[pixel] = i
-    const nStops = data[i++]
+    const nStops = read(i++)
+
     for (let stopIdx = 0; stopIdx < nStops; stopIdx++) {
-      stopId += data[i]
+      stopId += read(i)
       data[i++] = stopId
-      time += data[i]
+      time += read(i)
       data[i++] = time
     }
+
+    pixelsRead++
+  }
+
+  if (pixelsRead !== size) {
+    throw new Error(`Expected to read ${size} pixels but read only ${pixelsRead}`)
   }
 
   return stopTreeCache


### PR DESCRIPTION
fixes #72.

This will also prevent (though not solve) conveyal/analysis-ui#327.